### PR TITLE
Make sure headers are consistent.

### DIFF
--- a/docs/appservice/appservice.md
+++ b/docs/appservice/appservice.md
@@ -1,3 +1,5 @@
+# Appservice
+
 Draupnir can be run as an appservice, allowing users you trust or on your homeserver to run their own Draupnir without hosting anything themselves.
 This module is currently alpha quality and is subject to rapid changes,
 it is not recommended currently and support will be limited.
@@ -31,6 +33,7 @@ Please note that Draupnir in appservice mode does not support E2EE nor support u
 6. Create a `config/config.production.yaml` file that can be copied from the example in `config/default.yaml` just like in step 4. The file also needs to be accessible to the container so whatever path is used for `config/config.appservice.yaml` can be reused to also house this file.
 
 The provisioned Draupnirs only inherit a subset of the configuration options that are accessible to Bot mode Draupnir. Those are the following options. If there's `:` as a suffix to a config option that means there are sub options like how under commands in the default config you also find `additionalPrefixes:` with a value of `draupnir`.
+
 ```
 logLevel
 syncOnStartup
@@ -45,6 +48,7 @@ protections:
 7. Start the application service `docker run -v /your/path/to/draupnir-data/:/data/ gnuxie/draupnir appservice -c /data/config/config.appservice.yaml -f /data/config/draupnir-registration.yaml -p $MATRIX_PORT --draupnir-config /data/config/production.yaml`
 
 8. Copy the `draupnir-registration.yaml` to your matrix homeserver and refer to it in `homeserver.yaml` like so:
+
 ```
   app_service_config_files:
     - "/data/draupnir-registration.yaml"
@@ -62,9 +66,9 @@ If you successfully followed Steps 1-8 or got to the point your running the bot 
 
 4. Decide if you want to allow provisioning per homeserver or per user. If you choose to only provision per user skip to step 6.
 
-5. Allow provisioning per homeserver. To provision per homeserver you write in your control room /plain MXID_OF_APPSERVICE_HERE allow @*:homeserver_to_allow
+5. Allow provisioning per homeserver. To provision per homeserver you write in your control room /plain MXID_OF_APPSERVICE_HERE allow @\*:homeserver_to_allow
 
 6. Allow provisioning per user. To Provision per user you write in your control room /plain MXID_OF_APPSERVICE_HERE allow MXID_TO_ALLOW
-FIXME: If the client is being dumb and adding escapes to lone instances of * in the command strip them out so you don't have to mandate /plain use to guarantee the client doesn’t screw the user over.
+   FIXME: If the client is being dumb and adding escapes to lone instances of \* in the command strip them out so you don't have to mandate /plain use to guarantee the client doesn’t screw the user over.
 
 7. Provisioning a Draupnir is done via inviting your main draupnir into a room. If the user who did it is allowed to Draupnir rejects the invite and provisions a Draupnir shortly and invites the user to the newly created policy list and control room for this Draupnir.

--- a/docs/bot/setup_docker.md
+++ b/docs/bot/setup_docker.md
@@ -1,6 +1,9 @@
+# Docker
+
 Draupnir is available on the Docker Hub as [`gnuxie/draupnir`](https://hub.docker.com/r/gnuxie/draupnir).
 
 Using docker, draupnir can be setup and ran in either of two ways;
+
 - Docker Run
 - Docker Compose
 

--- a/docs/bot/setup_selfbuild.md
+++ b/docs/bot/setup_selfbuild.md
@@ -1,3 +1,5 @@
+# Source
+
 These instructions are to build and run draupnir without using [Docker](./setup_docker.md).
 You need to have installed `yarn` 1.x and Node 18.
 

--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -1,3 +1,5 @@
+# Synapse module
+
 **This requires Synapse 1.53.0 or higher**
 
 Using the bot to manage your rooms is great, however if you want to use your ban lists
@@ -6,14 +8,16 @@ is needed. Primarily meant to block invites from undesired homeservers/users, Mj
 Synapse module is a way to interpret ban lists and apply them to your entire homeserver.
 
 First, install the module to your Synapse python environment:
+
 ```
 pip install -e "git+https://github.com/matrix-org/mjolnir.git#egg=mjolnir&subdirectory=synapse_antispam"
 ```
 
-*Note*: Where your python environment is depends on your installation method. Visit
+_Note_: Where your python environment is depends on your installation method. Visit
 [#synapse:matrix.org](https://matrix.to/#/#synapse:matrix.org) if you're not sure.
 
 Then add the following to your `homeserver.yaml`:
+
 ```yaml
 modules:
   - module: mjolnir.Module
@@ -33,27 +37,27 @@ modules:
       # to already be joined to the room - Mjolnir will not automatically join
       # these rooms.
       ban_lists:
-         - "!roomid:example.org"
+        - "!roomid:example.org"
       #message_max_length:
-         # Limit the characters in a message (event body) that a client can send in an event on this server.
-         # By default there is no limit (beyond the the limit the spec enforces on event size).
-         # Uncomment if you want messages to be limited to 510 characters.
-         #threshold: 510
+      # Limit the characters in a message (event body) that a client can send in an event on this server.
+      # By default there is no limit (beyond the the limit the spec enforces on event size).
+      # Uncomment if you want messages to be limited to 510 characters.
+      #threshold: 510
 
-         # Limit messages only in certain rooms rooms.
-         # By default all rooms will enforce the limit.
-         # Uncomment if you want messages to only be subject to character limits in certain rooms.
-         #rooms:
-         #  - "!vMvyOCeCxHsggkmALd:localhost:9999"
+      # Limit messages only in certain rooms rooms.
+      # By default all rooms will enforce the limit.
+      # Uncomment if you want messages to only be subject to character limits in certain rooms.
+      #rooms:
+      #  - "!vMvyOCeCxHsggkmALd:localhost:9999"
 
-         # Also hide messages from remote servers that are over the `message_limit`.
-         # By default only events from this server will be limited.
-         # WARNING: Remote users on other servers will still be able to messages over the limit.
-         # Uncomment to enforce the `message_limit` on events from remote servers.
-         #remote_servers: true
+      # Also hide messages from remote servers that are over the `message_limit`.
+      # By default only events from this server will be limited.
+      # WARNING: Remote users on other servers will still be able to messages over the limit.
+      # Uncomment to enforce the `message_limit` on events from remote servers.
+      #remote_servers: true
 ```
 
-*Note*: Although this is described as a "spam checker", it does much more than fight
+_Note_: Although this is described as a "spam checker", it does much more than fight
 spam.
 
 Be sure to change the configuration to match your setup. Your server is expected to

--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -42,19 +42,19 @@ modules:
       # Limit the characters in a message (event body) that a client can send in an event on this server.
       # By default there is no limit (beyond the the limit the spec enforces on event size).
       # Uncomment if you want messages to be limited to 510 characters.
-      #threshold: 510
+      #  threshold: 510
 
       # Limit messages only in certain rooms rooms.
       # By default all rooms will enforce the limit.
       # Uncomment if you want messages to only be subject to character limits in certain rooms.
-      #rooms:
-      #  - "!vMvyOCeCxHsggkmALd:localhost:9999"
+      #  rooms:
+      #    - "!vMvyOCeCxHsggkmALd:localhost:9999"
 
       # Also hide messages from remote servers that are over the `message_limit`.
       # By default only events from this server will be limited.
       # WARNING: Remote users on other servers will still be able to messages over the limit.
       # Uncomment to enforce the `message_limit` on events from remote servers.
-      #remote_servers: true
+      #  remote_servers: true
 ```
 
 _Note_: Although this is described as a "spam checker", it does much more than fight

--- a/docs/contributing/context.md
+++ b/docs/contributing/context.md
@@ -1,3 +1,5 @@
+# Context
+
 ## Context for developing Draupnir
 
 alternatively context that is essential for developing
@@ -73,19 +75,19 @@ parts. You should read specification about policy lists
 after this introduction.
 
 - `entity`: This is the target of a given policy such as a user that
-is being banned.
+  is being banned.
 
 - `recommendation`: This is basically what the policy recommends that
-the "consumer" does. The only specified recommendation in the matrix
-spec is `m.ban`. How `m.ban` is interpreted is even left to
-interpretation, as it depends on what the "consumer" of the policy is.
-In Draupnir's case, it usually means to ban the user from any
-protected room.
+  the "consumer" does. The only specified recommendation in the matrix
+  spec is `m.ban`. How `m.ban` is interpreted is even left to
+  interpretation, as it depends on what the "consumer" of the policy is.
+  In Draupnir's case, it usually means to ban the user from any
+  protected room.
 
 - `reason`: This field is used by the `m.ban` recommendation as a
-place to replicate the "reason" field found when banning a user
-at the room level. It's not clear whether the field will be
-appropriate for all uses of `recommendation`.
+  place to replicate the "reason" field found when banning a user
+  at the room level. It's not clear whether the field will be
+  appropriate for all uses of `recommendation`.
 
 Currently there are only three state events that are defined by the
 spec and these were chosen to be intrinsically tied to the entities
@@ -151,7 +153,8 @@ This effort is now continued by the Matrix community in the form
 of Draupnir and [MTRNord](https://github.com/MTRNord)'s
 [Draupnir4all deployment](https://docs.draupnir.midnightthoughts.space/).
 
-[^full-state]: matrix-bot-sdk could be modified to sync with
-`full_state` set to true. This has been
-[attempted](https://github.com/turt2live/matrix-bot-sdk/pull/215)
-but the maintainer of the matrix-bot-sdk is opposed to the idea.
+[^full-state]:
+    matrix-bot-sdk could be modified to sync with
+    `full_state` set to true. This has been
+    [attempted](https://github.com/turt2live/matrix-bot-sdk/pull/215)
+    but the maintainer of the matrix-bot-sdk is opposed to the idea.


### PR DESCRIPTION
Docusoarus is inferring the title from the filename if we don't set a top level header in the markdown.

I have no idea why vscode went nuts but whatever.

![image](https://github.com/the-draupnir-project/draupnir-documentation/assets/50846879/93470c3b-f8d5-4d6c-ada4-1b877dc29cd5)
