### PR TITLE
Add Docker instructions for bind mounting the synapse module

### DIFF
--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -84,7 +84,7 @@ on your homeserver join. The antispam module will not join the rooms for you.
 If you change the configuration, you will need to restart Synapse. You'll also need
 to restart Synapse to install the plugin.
 
-### Docker 
+### Docker
 Installations that use the Docker image of `synapse` that wish to use the synapse module require the `./Draupnir/synapse_antispam/mjolnir` project directory to be bind mounted into the `synapse` container's `/usr/local/lib/python3.11/site-packages/mjolnir` directory.  Clone the project (`git clone https://github.com/the-draupnir-project/Draupnir`), then use the following `docker-compose` block as an example.
 
 ```yaml

--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -83,3 +83,14 @@ on your homeserver join. The antispam module will not join the rooms for you.
 
 If you change the configuration, you will need to restart Synapse. You'll also need
 to restart Synapse to install the plugin.
+
+### Docker 
+Installations that use the Docker image of `synapse` that wish to use the synapse module require the `./Draupnir/synapse_antispam/mjolnir` project directory to be bind mounted into the `synapse` container's `/usr/local/lib/python3.11/site-packages/mjolnir` directory.  Clone the project (`git clone https://github.com/the-draupnir-project/Draupnir`), then use the following `docker-compose` block as an example.
+
+```yaml
+version: '3.7'
+services:
+  synapse:
+    volumes:
+      - /<path>/draupnir/synapse_antispam/mjolnir:/usr/local/lib/python3.11/site-packages/mjolnir
+```


### PR DESCRIPTION
This will help people bind mount the correct directory and get the synapse module working.  The only problem I foresee is when synapse updates the version of python it is using, so it would be preferable if `synapse` contained a `plugin` directory that we could just bind mount the folder to, but that sounds like a feature request for `synapse`.

Special thanks to @daedric7 (@daedric:aguiarvieira.pt) for assisting me on figuring this out!

Signed-off-by: thomcat me@thomcat.rocks