### PR TITLE
Refer to Python 3.12 instead of 3.11 in the case of Synapse Docker image

### DIFF
--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -97,12 +97,12 @@ to restart Synapse to install the plugin.
 
 ### Docker
 
-Installations that use the Docker image of `synapse` that wish to use the synapse module require the `./Draupnir/synapse_antispam/mjolnir` project directory to be bind mounted into the `synapse` container's `/usr/local/lib/python3.11/site-packages/mjolnir` directory.  Clone the project (`git clone https://github.com/the-draupnir-project/Draupnir`), then use the following `docker-compose` block as an example.
+Installations that use the Docker image of `synapse` that wish to use the synapse module require the `./Draupnir/synapse_antispam/mjolnir` project directory to be bind mounted into the `synapse` container's `/usr/local/lib/python3.12/site-packages/mjolnir` directory.  Clone the project (`git clone https://github.com/the-draupnir-project/Draupnir`), then use the following `docker-compose` block as an example.
 
 ```yaml
 version: '3.7'
 services:
   synapse:
     volumes:
-      - /<path>/draupnir/synapse_antispam/mjolnir:/usr/local/lib/python3.11/site-packages/mjolnir
+      - /<path>/draupnir/synapse_antispam/mjolnir:/usr/local/lib/python3.12/site-packages/mjolnir
 ```


### PR DESCRIPTION
Synapse docker image has been on 3.12 for a long time at this point.