### PR TITLE
Add warning that Synapse Module is known broken with workers

### DIFF
--- a/docs/bot/synapse_module.md
+++ b/docs/bot/synapse_module.md
@@ -14,7 +14,7 @@ module will still be compatible with Draupnir's policy lists.
 
 :::
 
-:::info
+:::warning
 
 When Synapse workers are used, changes to policy lists may not
 propagate to all workers until Synapse is restarted.


### PR DESCRIPTION
Heres even how it looks deployed in dark mode.

![image](https://github.com/user-attachments/assets/676df3c7-d7b2-47e7-a39e-78d7ab274a9c)
