### PR TITLE
add ansible playbook link

### DIFF
--- a/docs/bot/setup_debian.md
+++ b/docs/bot/setup_debian.md
@@ -14,6 +14,13 @@ This installation method is intended for experienced sysadmins.
 
 :::
 
+:::note
+
+Based on these instructions, there's an [Ansible playbook](https://codeberg.org/Tealk/ansible_collection/src/branch/develop/playbooks/update-draupnir.yml) that install Draupnir and also applies the configuration. \
+**Secrets should be secured with Ansible Vault!**
+
+:::
+
 ## Installation
 
 install git curl and sudo


### PR DESCRIPTION
Based on the Debian guide, I created an Ansible playbook that executes the steps. It's part of my repo, so users would have to transfer it into their own playbook.

If that's not desired, I can also transfer it to a separate repo.
