### PR TITLE
Renovate Automatic Release Tag Updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,27 @@
 {
   extends: ["github>the-draupnir-project/.github:renovate-shared"],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Update Draupnir release tags used in docs command examples",
+      managerFilePatterns: ["/(^|/)docs/.*\\.md$/"],
+      datasourceTemplate: "github-tags",
+      depNameTemplate: "the-draupnir-project/Draupnir",
+      versioningTemplate: "semver-coerced",
+      matchStrings: [
+        "git clone --branch v(?<currentValue>\\d+\\.\\d+\\.\\d+) --depth 1 https://github\\.com/the-draupnir-project/Draupnir\\.git(?:\\s+\\S+)?",
+        "cd\\s+[^\\n]*Draupnir[^\\n]*&&\\s+git\\s+fetch\\s+--tags\\s+&&\\s+git\\s+checkout\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
+    }
+  ],
+  packageRules: [
+    {
+      description: "Automerge Draupnir docs tag updates",
+      matchManagers: ["custom.regex"],
+      matchDatasources: ["github-tags"],
+      matchPackageNames: ["the-draupnir-project/Draupnir"],
+      matchFileNames: ["docs/**/*.md"],
+      automerge: true
+    }
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,13 +3,14 @@
   customManagers: [
     {
       customType: "regex",
-      description: "Update Draupnir release tags used in docs command examples",
+      description: "Update explicitly annotated Draupnir release tags in docs",
       managerFilePatterns: ["/(^|/)docs/.*\\.md$/"],
       datasourceTemplate: "github-tags",
       depNameTemplate: "the-draupnir-project/Draupnir",
       versioningTemplate: "semver-coerced",
       matchStrings: [
-        "^(?=[^\\n]*Draupnir)(?=[^\\n]*git[^\\n]*(?:checkout|branch|clone[^\\n]*--branch)[^\\n]*v(?<currentValue>\\d+\\.\\d+\\.\\d+)).*$",
+        "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git clone --branch v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
+        "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git checkout v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
       ],
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,10 +9,9 @@
       depNameTemplate: "the-draupnir-project/Draupnir",
       versioningTemplate: "semver-coerced",
       matchStrings: [
-        "git clone --branch v(?<currentValue>\\d+\\.\\d+\\.\\d+) --depth 1 https://github\\.com/the-draupnir-project/Draupnir\\.git(?:\\s+\\S+)?",
-        "cd\\s+[^\\n]*Draupnir[^\\n]*&&\\s+git\\s+fetch\\s+--tags\\s+&&\\s+git\\s+checkout\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ]
-    }
+        "^(?=[^\\n]*Draupnir)(?=[^\\n]*git[^\\n]*(?:checkout|branch|clone[^\\n]*--branch)[^\\n]*v(?<currentValue>\\d+\\.\\d+\\.\\d+)).*$",
+      ],
+    },
   ],
   packageRules: [
     {
@@ -21,7 +20,7 @@
       matchDatasources: ["github-tags"],
       matchPackageNames: ["the-draupnir-project/Draupnir"],
       matchFileNames: ["docs/**/*.md"],
-      automerge: true
-    }
-  ]
+      automerge: false,
+    },
+  ],
 }

--- a/docs/bot/setup_debian.md
+++ b/docs/bot/setup_debian.md
@@ -53,6 +53,8 @@ mkdir -p /opt/mod-bot
 
 Clone the repository and fetch the tags:
 
+<!-- renovate: draupnir-install-tag -->
+
 ```shell
 git clone --branch v3.0.0 --depth 1 https://github.com/the-draupnir-project/Draupnir.git /opt/mod-bot/Draupnir
 git -C /opt/mod-bot/Draupnir fetch --tags
@@ -173,6 +175,8 @@ systemctl stop draupnir
 ```
 
 Fetch updates from GitHub and check out the version you want:
+
+<!-- renovate: draupnir-install-tag -->
 
 ```shell
 sudo -u draupnir bash -c "cd /opt/mod-bot/Draupnir && git fetch --tags && git checkout v3.0.0"

--- a/docs/bot/setup_selfbuild.md
+++ b/docs/bot/setup_selfbuild.md
@@ -22,6 +22,7 @@ This guide is meant to be read in conjunction with
 These instructions are to build and run Draupnir without using
 [Docker](./setup_docker.md). You need to have installed Node.js 24 and `npm`.
 
+<!-- renovate: draupnir-install-tag -->
 ```bash
 git clone --branch v3.0.0 --depth 1 https://github.com/the-draupnir-project/Draupnir.git
 cd Draupnir


### PR DESCRIPTION
This was made with the assumption that #126 is merged but its technically independent. Its just i cant guarantee full functionality due to how the regex works.

Also since we dont allow rollback PRs we arent getting screwed by pinning to 3.0.0 ahead of 3.0.0 release.