### PR TITLE
Move to GHCR recomendation and deprechate the use of latest in docs.

### DIFF
--- a/.github/REUSE.toml
+++ b/.github/REUSE.toml
@@ -7,6 +7,8 @@ version = 1
 
 [[annotations]]
 path = "renovate.json5"
-SPDX-FileCopyrightText = "2024 Aminda Suomalainen <suomalainen@aminda.eu>"
-SPDX-FileCopyrightText = "2026 Catalan Lover <catalanlover@protonmail.com>"
-SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = [
+    "2024 Aminda Suomalainen <suomalainen@aminda.eu>",
+    "2026 Catalan Lover <catalanlover@protonmail.com>",
+]
+SPDX-License-Identifier = "0BSD"

--- a/.github/REUSE.toml
+++ b/.github/REUSE.toml
@@ -8,4 +8,5 @@ version = 1
 [[annotations]]
 path = "renovate.json5"
 SPDX-FileCopyrightText = "2024 Aminda Suomalainen <suomalainen@aminda.eu>"
-SPDX-License-Identifier = "0BSD"
+SPDX-FileCopyrightText = "2026 Catalan Lover <catalanlover@protonmail.com>"
+SPDX-License-Identifier = "Apache-2.0"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,8 @@
       matchStrings: [
         "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git clone --branch v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
         "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git checkout v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
+        "<!-- renovate: docker-tag -->[\\s\\S]*?the-draupnir-project/draupnir:(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
+        "<!-- renovate: systemd-tag -->[\\s\\S]*?Environment=DRAUPNIR_TAG=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b"
       ],
     },
   ],
@@ -21,7 +23,7 @@
       matchDatasources: ["github-tags"],
       matchPackageNames: ["the-draupnir-project/Draupnir"],
       matchFileNames: ["docs/**/*.md"],
-      automerge: true,
+      automerge: false,
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
       matchStrings: [
         "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git clone --branch v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
         "<!-- renovate: draupnir-install-tag -->[\\s\\S]*?git checkout v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
-        "<!-- renovate: docker-tag -->[\\s\\S]*?the-draupnir-project/draupnir:(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
+        "<!-- renovate: docker-tag -->[\\s\\S]*?ghcr.io/the-draupnir-project/draupnir:(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
         "<!-- renovate: systemd-tag -->[\\s\\S]*?Environment=DRAUPNIR_TAG=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b"
       ],
     },

--- a/docs/appservice/appservice.md
+++ b/docs/appservice/appservice.md
@@ -28,7 +28,7 @@ Please note that Draupnir in appservice mode does not support E2EE nor support u
 5. Generate the appservice registration file. This will be used by both the appservice and your homeserver.
    Here, you must specify the direct link the Matrix Homeserver can use to access the appservice, including the Matrix port it will send messages through (if this bridge runs on the same machine you can use `localhost` as the `$HOST` name):
 
-   `docker run --rm -v /your/path/to/draupnir-data:/data the-draupnir-project/draupnir appservice -r -u "http://$HOST:$MATRIX_PORT" -f /data/config/draupnir-registration.yaml`
+   `docker run --rm -v /your/path/to/draupnir-data:/data ghcr.io/the-draupnir-project/draupnir appservice -r -u "http://$HOST:$MATRIX_PORT" -f /data/config/draupnir-registration.yaml`
 
 6. Create a `config/config.production.yaml` file that can be copied from the example in `config/default.yaml` just like in step 4. The file also needs to be accessible to the container so whatever path is used for `config/config.appservice.yaml` can be reused to also house this file.
 
@@ -45,7 +45,7 @@ commands:
 protections:
 ```
 
-7. Start the application service `docker run -v /your/path/to/draupnir-data/:/data/ the-draupnir-project/draupnir appservice -c /data/config/config.appservice.yaml -f /data/config/draupnir-registration.yaml -p $MATRIX_PORT --draupnir-config /data/config/production.yaml`
+7. Start the application service `docker run -v /your/path/to/draupnir-data/:/data/ ghcr.io/the-draupnir-project/draupnir appservice -c /data/config/config.appservice.yaml -f /data/config/draupnir-registration.yaml -p $MATRIX_PORT --draupnir-config /data/config/production.yaml`
 
 8. Copy the `draupnir-registration.yaml` to your matrix homeserver and refer to it in `homeserver.yaml` like so:
 

--- a/docs/appservice/appservice.md
+++ b/docs/appservice/appservice.md
@@ -28,7 +28,7 @@ Please note that Draupnir in appservice mode does not support E2EE nor support u
 5. Generate the appservice registration file. This will be used by both the appservice and your homeserver.
    Here, you must specify the direct link the Matrix Homeserver can use to access the appservice, including the Matrix port it will send messages through (if this bridge runs on the same machine you can use `localhost` as the `$HOST` name):
 
-   `docker run --rm -v /your/path/to/draupnir-data:/data gnuxie/draupnir appservice -r -u "http://$HOST:$MATRIX_PORT" -f /data/config/draupnir-registration.yaml`
+   `docker run --rm -v /your/path/to/draupnir-data:/data the-draupnir-project/draupnir appservice -r -u "http://$HOST:$MATRIX_PORT" -f /data/config/draupnir-registration.yaml`
 
 6. Create a `config/config.production.yaml` file that can be copied from the example in `config/default.yaml` just like in step 4. The file also needs to be accessible to the container so whatever path is used for `config/config.appservice.yaml` can be reused to also house this file.
 
@@ -45,7 +45,7 @@ commands:
 protections:
 ```
 
-7. Start the application service `docker run -v /your/path/to/draupnir-data/:/data/ gnuxie/draupnir appservice -c /data/config/config.appservice.yaml -f /data/config/draupnir-registration.yaml -p $MATRIX_PORT --draupnir-config /data/config/production.yaml`
+7. Start the application service `docker run -v /your/path/to/draupnir-data/:/data/ the-draupnir-project/draupnir appservice -c /data/config/config.appservice.yaml -f /data/config/draupnir-registration.yaml -p $MATRIX_PORT --draupnir-config /data/config/production.yaml`
 
 8. Copy the `draupnir-registration.yaml` to your matrix homeserver and refer to it in `homeserver.yaml` like so:
 

--- a/docs/bot/setup_docker.md
+++ b/docs/bot/setup_docker.md
@@ -99,5 +99,5 @@ the first argument that gets passed to the container is `bot`.
 So for example: o start Draupnir, you could use the following command:
 <!-- renovate: docker-tag -->
 ```bash
-docker run --rm -it --name=draupnir -v ./var/lib/draupnir:/data the-draupnir-project/draupnir:3.1.0 bot --draupnir-config /data/config/production.yaml
+docker run --rm -it --name=draupnir -v ./var/lib/draupnir:/data ghcr.io/the-draupnir-project/draupnir:3.1.0 bot --draupnir-config /data/config/production.yaml
 ```

--- a/docs/bot/setup_docker.md
+++ b/docs/bot/setup_docker.md
@@ -16,9 +16,12 @@ of [using Docker with systemd](./systemd).
 
 ## Images
 
-Draupnir is available as an image from Docker Hub as
-[`gnuxie/draupnir`](https://hub.docker.com/r/gnuxie/draupnir/tags).
-Draupnir is available under the following release tags:
+Draupnir is available via Github Container Repository and Docker Hub.
+GHCR is the recommended distribution pathway for Draupnir images and is found under
+[`the-draupnir-project/draupnir`](https://github.com/the-draupnir-project/Draupnir/pkgs/container/draupnir)
+
+We also have our legacy Docker Hub distribution in parallel with GHCR under
+[`gnuxie/draupnir`](https://hub.docker.com/r/gnuxie/draupnir/tags)
 
 ### `latest`
 
@@ -47,12 +50,27 @@ GitHub](https://github.com/the-draupnir-project/Draupnir/releases).
 If there are pre-releases, you should scroll down until you find the
 latest release.
 
-### `develop`
+### `main`
 
-The `develop` tag will always refer to an image built from the `main`
+The `main` tag will always refer to an image built from the `main`
 branch of Draupnir's git repository. You will not experience any
 severe breakages by using this tag, but you will want to be present
 within the Draupnir support room.
+
+This tag is GHCR Exclusive. Its functionally equivalent to `develop`
+tag from Docker Hub.
+
+### Branch Tags
+
+Draupnir GHCR images are released for development branches. This
+is especially useful when wanting to do dev testing against feature
+branches. All the work for Zero Touch Deployment Stage 1 for example
+was using this feature to be tested before it was merged into main.
+That testing as done using [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy)
+together with a branch docker image.
+
+These branch docker images are only rebuilt when that branch is pushed
+to and only intended for development usage.
 
 ## Running with Docker
 
@@ -79,7 +97,7 @@ for when providing options with `docker run`. This is done by ensuring
 the first argument that gets passed to the container is `bot`.
 
 So for example: o start Draupnir, you could use the following command:
-
+<!-- renovate: docker-tag -->
 ```bash
-docker run --rm -it --name=draupnir -v ./var/lib/draupnir:/data gnuxie/draupnir:latest bot --draupnir-config /data/config/production.yaml
+docker run --rm -it --name=draupnir -v ./var/lib/draupnir:/data the-draupnir-project/draupnir:3.1.0 bot --draupnir-config /data/config/production.yaml
 ```

--- a/docs/bot/systemd.md
+++ b/docs/bot/systemd.md
@@ -26,6 +26,7 @@ You will then want to copy your configuration file for Draupnir to
 Then you will want to copy the following systemd unit file to
 `/etc/systemd/system/draupnir.service`.
 
+<!-- renovate: systemd-tag -->
 ```ini
 [Unit]
 Description=Draupnir Docker Container
@@ -37,12 +38,14 @@ Wants=network-online.target
 
 [Service]
 Type=exec
+# This controls the docker tag your bot is pinned to. Update it to Switch draupnir version.
+Environment=DRAUPNIR_TAG=3.1.0
 # Update Draupnir
-ExecStartPre=docker image pull gnuxie/draupnir:latest
+ExecStartPre=docker image pull the-draupnir-project/draupnir:${DRAUPNIR_TAG}
 # Clean up any accidentally existing containers
 ExecStartPre=docker container rm --force draupnir
 
-ExecStart=docker container run --rm --pull=never --name=draupnir -v /var/lib/draupnir:/data gnuxie/draupnir:latest bot --draupnir-config /data/config/production.yaml
+ExecStart=docker container run --rm --pull=never --name=draupnir -v /var/lib/draupnir:/data the-draupnir-project/draupnir:${DRAUPNIR_TAG} bot --draupnir-config /data/config/production.yaml
 
 ExecStop=-docker container stop --time=10 draupnir
 

--- a/docs/bot/systemd.md
+++ b/docs/bot/systemd.md
@@ -41,11 +41,11 @@ Type=exec
 # This controls the docker tag your bot is pinned to. Update it to Switch draupnir version.
 Environment=DRAUPNIR_TAG=3.1.0
 # Update Draupnir
-ExecStartPre=docker image pull the-draupnir-project/draupnir:${DRAUPNIR_TAG}
+ExecStartPre=docker image pull ghcr.io/the-draupnir-project/draupnir:${DRAUPNIR_TAG}
 # Clean up any accidentally existing containers
 ExecStartPre=docker container rm --force draupnir
 
-ExecStart=docker container run --rm --pull=never --name=draupnir -v /var/lib/draupnir:/data the-draupnir-project/draupnir:${DRAUPNIR_TAG} bot --draupnir-config /data/config/production.yaml
+ExecStart=docker container run --rm --pull=never --name=draupnir -v /var/lib/draupnir:/data ghcr.io/the-draupnir-project/draupnir:${DRAUPNIR_TAG} bot --draupnir-config /data/config/production.yaml
 
 ExecStop=-docker container stop --time=10 draupnir
 


### PR DESCRIPTION
Why have Renovate manage to keep version tags up to date if not for this purpose?

Also Remember to switch Automerge to on after we validate that these Regexes actually work.